### PR TITLE
Add Keycloak 22 MariaDB federation sample

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+KEYCLOAK_VERSION ?= 22.0.5
+JAR_NAME = UserStorageFederation-0.0.1.jar
+
+build:
+\tmvn -DskipTests package
+
+run-db:
+\tdocker run -d --name federation-mariadb \\
+\t\t-e MARIADB_USER=keycloak \\
+\t\t-e MARIADB_PASSWORD=password \\
+\t\t-e MARIADB_ROOT_PASSWORD=root \\
+\t\t-e MARIADB_DATABASE=keycloak_external \\
+\t\t-p 3306:3306 mariadb:latest
+
+run-keycloak: build
+\tdocker run --rm -it -p 8080:8080 \\
+\t\t-e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin \\
+\t\t-v $(PWD)/target/$(JAR_NAME):/opt/keycloak/providers/$(JAR_NAME) \\
+\t\tquay.io/keycloak/keycloak:$(KEYCLOAK_VERSION) start-dev
+
+clean:
+\tdocker rm -f federation-mariadb || true
+\trm -rf target
+
+.PHONY: build run-db run-keycloak clean

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>0.0.1</version>
 
     <properties>
-        <version.keycloak>26.0.8</version.keycloak>
+        <version.keycloak>22.0.5</version.keycloak>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -17,8 +17,23 @@
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-model-storage</artifactId>
-            <version>26.0.7</version>
+            <artifactId>keycloak-server-spi</artifactId>
+            <version>${version.keycloak}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+            <version>${version.keycloak}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
@@ -4,6 +4,7 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.credential.CredentialInputUpdater;
 import org.keycloak.credential.CredentialInputValidator;
+import org.keycloak.models.credential.CredentialModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -14,8 +15,11 @@ import org.keycloak.storage.user.UserQueryProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
 
 import java.util.Map;
-import java.util.Properties;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import net.minet.keycloak.spi.entity.ExternalUser;
 import java.util.stream.Stream;
+import org.keycloak.storage.adapter.AbstractUserAdapterFederatedStorage;
 
 public class FdpSQLUserStorageProvider implements
         UserStorageProvider,
@@ -26,13 +30,17 @@ public class FdpSQLUserStorageProvider implements
         UserQueryProvider {
 
     protected KeycloakSession session;
-    protected Properties properties;
+    protected EntityManager em;
     protected ComponentModel model;
 
-    public FdpSQLUserStorageProvider(KeycloakSession keycloakSession, ComponentModel componentModel, Properties props) {
+    public FdpSQLUserStorageProvider(KeycloakSession keycloakSession, ComponentModel componentModel, EntityManager em) {
         this.model = componentModel;
         this.session = keycloakSession;
-        this.properties = props;
+        this.em = em;
+    }
+
+    protected UserModel createAdapter(RealmModel realm, ExternalUser user) {
+        return new ExternalUserAdapter(session, realm, model, user);
     }
 
     @Override
@@ -42,32 +50,65 @@ public class FdpSQLUserStorageProvider implements
 
     @Override
     public void close() {
-
+        if (em.isOpen()) {
+            em.close();
+        }
     }
 
     @Override
-    public UserModel getUserById(RealmModel realmModel, String s) {
-        return null;
+    public UserModel getUserById(RealmModel realmModel, String id) {
+        ExternalUser user = null;
+        try {
+            user = em.find(ExternalUser.class, Long.parseLong(id));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        if (user == null) return null;
+        return createAdapter(realmModel, user);
     }
 
     @Override
-    public UserModel getUserByUsername(RealmModel realmModel, String s) {
-        return null;
+    public UserModel getUserByUsername(RealmModel realmModel, String username) {
+        try {
+            ExternalUser user = em.createQuery("select u from ExternalUser u where u.username = :username", ExternalUser.class)
+                    .setParameter("username", username)
+                    .getSingleResult();
+            return createAdapter(realmModel, user);
+        } catch (NoResultException ex) {
+            return null;
+        }
     }
 
     @Override
-    public UserModel getUserByEmail(RealmModel realmModel, String s) {
-        return null;
+    public UserModel getUserByEmail(RealmModel realmModel, String email) {
+        try {
+            ExternalUser user = em.createQuery("select u from ExternalUser u where u.email = :email", ExternalUser.class)
+                    .setParameter("email", email)
+                    .getSingleResult();
+            return createAdapter(realmModel, user);
+        } catch (NoResultException ex) {
+            return null;
+        }
     }
 
     @Override
-    public boolean supportsCredentialType(String s) {
-        return false;
+    public boolean supportsCredentialType(String type) {
+        return CredentialModel.PASSWORD.equals(type);
     }
 
     @Override
     public boolean updateCredential(RealmModel realmModel, UserModel userModel, CredentialInput credentialInput) {
-        return false;
+        if (!supportsCredentialType(credentialInput.getType())) {
+            return false;
+        }
+        ExternalUser user = em.find(ExternalUser.class, Long.parseLong(userModel.getId()));
+        if (user == null) {
+            return false;
+        }
+        em.getTransaction().begin();
+        user.setPassword(credentialInput.getChallengeResponse());
+        em.getTransaction().commit();
+        return true;
     }
 
     @Override
@@ -81,28 +122,44 @@ public class FdpSQLUserStorageProvider implements
     }
 
     @Override
-    public boolean isConfiguredFor(RealmModel realmModel, UserModel userModel, String s) {
-        return false;
+    public boolean isConfiguredFor(RealmModel realmModel, UserModel userModel, String type) {
+        return supportsCredentialType(type);
     }
 
     @Override
     public boolean isValid(RealmModel realmModel, UserModel userModel, CredentialInput credentialInput) {
-        return false;
+        if (!supportsCredentialType(credentialInput.getType())) {
+            return false;
+        }
+        ExternalUser user = em.find(ExternalUser.class, Long.parseLong(userModel.getId()));
+        return user != null && credentialInput.getChallengeResponse().equals(user.getPassword());
     }
 
     @Override
-    public UserModel addUser(RealmModel realmModel, String s) {
-        return null;
+    public UserModel addUser(RealmModel realmModel, String username) {
+        ExternalUser user = new ExternalUser();
+        user.setUsername(username);
+        em.getTransaction().begin();
+        em.persist(user);
+        em.getTransaction().commit();
+        return createAdapter(realmModel, user);
     }
 
     @Override
     public boolean removeUser(RealmModel realmModel, UserModel userModel) {
-        return false;
+        ExternalUser user = em.find(ExternalUser.class, Long.parseLong(userModel.getId()));
+        if (user == null) return false;
+        em.getTransaction().begin();
+        em.remove(user);
+        em.getTransaction().commit();
+        return true;
     }
 
     @Override
     public Stream<UserModel> searchForUserStream(RealmModel realmModel, Map<String, String> map, Integer integer, Integer integer1) {
-        return Stream.empty();
+        return em.createQuery("select u from ExternalUser u", ExternalUser.class)
+                .getResultStream()
+                .map(user -> createAdapter(realmModel, user));
     }
 
     @Override
@@ -113,5 +170,55 @@ public class FdpSQLUserStorageProvider implements
     @Override
     public Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realmModel, String s, String s1) {
         return Stream.empty();
+    }
+
+    private static class ExternalUserAdapter extends AbstractUserAdapterFederatedStorage {
+        private final ExternalUser user;
+
+        ExternalUserAdapter(KeycloakSession session, RealmModel realm, ComponentModel model, ExternalUser user) {
+            super(session, realm, model);
+            this.user = user;
+            setEntityId(String.valueOf(user.getId()));
+        }
+
+        @Override
+        public String getUsername() {
+            return user.getUsername();
+        }
+
+        @Override
+        public void setUsername(String username) {
+            user.setUsername(username);
+        }
+
+        @Override
+        public String getEmail() {
+            return user.getEmail();
+        }
+
+        @Override
+        public void setEmail(String email) {
+            user.setEmail(email);
+        }
+
+        @Override
+        public String getFirstName() {
+            return user.getFirstName();
+        }
+
+        @Override
+        public void setFirstName(String firstName) {
+            user.setFirstName(firstName);
+        }
+
+        @Override
+        public String getLastName() {
+            return user.getLastName();
+        }
+
+        @Override
+        public void setLastName(String lastName) {
+            user.setLastName(lastName);
+        }
     }
 }

--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderFactory.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderFactory.java
@@ -1,36 +1,40 @@
 package net.minet.keycloak.spi;
 
+import org.keycloak.Config;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.storage.UserStorageProviderFactory;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
 
 public class FdpSQLUserStorageProviderFactory implements
         UserStorageProviderFactory<FdpSQLUserStorageProvider> {
 
-    public static final String PROVIDER_NAME = "FdpSQL";
+    public static final String PROVIDER_NAME = "fdp-sql";
+
+    private EntityManagerFactory emf;
+
+    @Override
+    public void init(Config.Scope config) {
+        this.emf = Persistence.createEntityManagerFactory("federation");
+    }
 
     @Override
     public FdpSQLUserStorageProvider create(KeycloakSession keycloakSession, ComponentModel componentModel) {
-        Properties props = new Properties();
-        try {
-            InputStream is = new FileInputStream("TEST");
-            props.load(is);
-            is.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        return new FdpSQLUserStorageProvider(keycloakSession, componentModel, props);
+        return new FdpSQLUserStorageProvider(keycloakSession, componentModel, emf.createEntityManager());
     }
 
     @Override
     public String getId() {
-        return "";
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public void close() {
+        if (emf != null) {
+            emf.close();
+        }
     }
 }

--- a/src/main/java/net/minet/keycloak/spi/entity/ExternalUser.java
+++ b/src/main/java/net/minet/keycloak/spi/entity/ExternalUser.java
@@ -1,0 +1,74 @@
+package net.minet.keycloak.spi.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "external_user")
+public class ExternalUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column
+    private String password;
+
+    @Column
+    private String email;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/src/main/resources/META-INF/org.keycloak.storage.UserStorageProviderFactory
+++ b/src/main/resources/META-INF/org.keycloak.storage.UserStorageProviderFactory
@@ -1,1 +1,1 @@
-net.minet.keycloak.spi.fdpsqluserfederation.FdpSQLUserStorageProviderFactory
+net.minet.keycloak.spi.FdpSQLUserStorageProviderFactory

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             version="3.0">
+  <persistence-unit name="federation">
+    <class>net.minet.keycloak.spi.entity.ExternalUser</class>
+    <properties>
+      <property name="jakarta.persistence.jdbc.driver" value="org.mariadb.jdbc.Driver"/>
+      <property name="jakarta.persistence.jdbc.url" value="jdbc:mariadb://localhost:3306/keycloak_external"/>
+      <property name="jakarta.persistence.jdbc.user" value="keycloak"/>
+      <property name="jakarta.persistence.jdbc.password" value="password"/>
+      <property name="hibernate.hbm2ddl.auto" value="update"/>
+    </properties>
+  </persistence-unit>
+</persistence>


### PR DESCRIPTION
## Summary
- update dependencies for Keycloak 22
- implement simple JPA user federation provider
- add JPA entity and persistence config for MariaDB
- register provider and supply Makefile with docker helpers

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a87a392148326a87e528e27346654