### PR TITLE
Add Makefile target for CAS DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,34 @@ KEYCLOAK_VERSION ?= 22.0.5
 JAR_NAME = UserStorageFederation-0.0.1.jar
 
 build:
-\tmvn -DskipTests package
+	mvn -DskipTests package
 
 run-db:
-\tdocker run -d --name federation-mariadb \\
-\t\t-e MARIADB_USER=keycloak \\
-\t\t-e MARIADB_PASSWORD=password \\
-\t\t-e MARIADB_ROOT_PASSWORD=root \\
-\t\t-e MARIADB_DATABASE=keycloak_external \\
-\t\t-p 3306:3306 mariadb:latest
+	docker run -d --name federation-mariadb \
+		-e MARIADB_USER=keycloak \
+		-e MARIADB_PASSWORD=password \
+		-e MARIADB_ROOT_PASSWORD=root \
+		-e MARIADB_DATABASE=keycloak_external \
+		-p 3306:3306 mariadb:latest
+
+run-cas-db:
+	docker run -d --name cas-mariadb \
+		-e MARIADB_USER=casuser \
+		-e MARIADB_PASSWORD=caspass \
+		-e MARIADB_ROOT_PASSWORD=root \
+		-e MARIADB_DATABASE=adh6_prod \
+		-v $(PWD)/sql:/docker-entrypoint-initdb.d \
+		-p 3307:3306 mariadb:latest
 
 run-keycloak: build
-\tdocker run --rm -it -p 8080:8080 \\
-\t\t-e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin \\
-\t\t-v $(PWD)/target/$(JAR_NAME):/opt/keycloak/providers/$(JAR_NAME) \\
-\t\tquay.io/keycloak/keycloak:$(KEYCLOAK_VERSION) start-dev
+	docker run --rm -it -p 8080:8080 \
+		-e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin \
+		-v $(PWD)/target/$(JAR_NAME):/opt/keycloak/providers/$(JAR_NAME) \
+		quay.io/keycloak/keycloak:$(KEYCLOAK_VERSION) start-dev
 
 clean:
-\tdocker rm -f federation-mariadb || true
-\trm -rf target
+	docker rm -f federation-mariadb || true
+	docker rm -f cas-mariadb || true
+	rm -rf target
 
-.PHONY: build run-db run-keycloak clean
+.PHONY: build run-db run-cas-db run-keycloak clean

--- a/sql/cas_schema.sql
+++ b/sql/cas_schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS adherents (
+    login VARCHAR(255) NOT NULL PRIMARY KEY,
+    prenom VARCHAR(255),
+    nom VARCHAR(255),
+    mail VARCHAR(255),
+    password VARCHAR(255)
+);


### PR DESCRIPTION
## Summary
- allow running a local MariaDB instance that mimics the CAS database
- provide schema for `adherents` table

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8e1ae5ac8326b8e0c6fc049a8775