### PR TITLE
Fix Byte Buddy Java 21 issue

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,6 +47,7 @@ services:
       KC_DB_URL: jdbc:mariadb://keycloak-db:3306/keycloak
       KC_DB_USERNAME: keycloak
       KC_DB_PASSWORD: password
+      JAVA_OPTS_APPEND: "-Dnet.bytebuddy.experimental=true"
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Summary
- update `docker-compose.dev.yml` to add JAVA_OPTS to enable experimental Byte Buddy support for Java 21

## Testing
- `make build` *(fails: mvn: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684adcacf41083268d2007692000972e