### PR TITLE
Fix dialect configuration for Hibernate

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -9,6 +9,7 @@
       <property name="jakarta.persistence.jdbc.user" value="keycloak"/>
       <property name="jakarta.persistence.jdbc.password" value="password"/>
       <property name="hibernate.hbm2ddl.auto" value="update"/>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.MariaDBDialect"/>
     </properties>
   </persistence-unit>
 </persistence>


### PR DESCRIPTION
## Summary
- ensure the JPA persistence unit explicitly sets the MariaDB dialect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684addc409308326b29f1e7714211666