### PR TITLE
Fix compose schema warning

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   keycloak-db:
     image: mariadb:10.6


### PR DESCRIPTION
## Summary
- remove obsolete `version` key from docker compose file

## Testing
- `docker compose -f docker-compose.dev.yml config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684adee1cee883269b839028aaa75b38