### PR TITLE
Fix Java version mismatch for Keycloak 22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,9 @@
 
     <properties>
         <version.keycloak>22.0.5</version.keycloak>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <!-- Keycloak 22 runs on Java 17 so compile the provider for that -->
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>


### PR DESCRIPTION
## Summary
- compile the provider with Java 17 so it runs with Keycloak 22

## Testing
- `make build` *(fails: could not download Maven plugin due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_684adfe4babc83269c857be555187c93