### PR TITLE
Switch to Keycloak 26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KEYCLOAK_VERSION ?= 22.0.5
+KEYCLOAK_VERSION ?= 26.2.5
 JAR_NAME = UserStorageFederation-0.0.1.jar
 
 build:
@@ -12,8 +12,8 @@ run-db:
 		-e MARIADB_DATABASE=keycloak_external \
 		-p 3306:3306 mariadb:latest
 
-run-cas-db:
-	docker run -d --name cas-mariadb \
+run-adh6-local-db:
+        docker run -d --name adh6-local-mariadb \
 		-e MARIADB_USER=casuser \
 		-e MARIADB_PASSWORD=caspass \
 		-e MARIADB_ROOT_PASSWORD=root \
@@ -28,8 +28,8 @@ run-keycloak: build
 		quay.io/keycloak/keycloak:$(KEYCLOAK_VERSION) start-dev
 
 clean:
-	docker rm -f federation-mariadb || true
-	docker rm -f cas-mariadb || true
+        docker rm -f federation-mariadb || true
+        docker rm -f adh6-local-mariadb || true
 	rm -rf target
 
-.PHONY: build run-db run-cas-db run-keycloak clean
+.PHONY: build run-db run-adh6-local-db run-keycloak clean

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FDP User Storage Federation
 
-This project provides a sample Keycloak 22 user storage federation provider backed by MariaDB.
+This project provides a sample Keycloak 26 user storage federation provider backed by MariaDB.
 
 ## License
 
@@ -20,6 +20,6 @@ Released under the MIT License. See [LICENSE](LICENSE) for details.
    docker compose -f docker-compose.dev.yml up
    ```
 
-The compose file starts Keycloak 22 with the provider JAR, a MariaDB instance for
+The compose file starts Keycloak 26 with the provider JAR, a MariaDB instance for
 Keycloak itself, and another MariaDB instance seeded with the `adherents` table
 for testing.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,19 +11,7 @@ services:
     volumes:
       - keycloak-db-data:/var/lib/mysql
 
-  federation-db:
-    image: mariadb:10.6
-    environment:
-      MARIADB_USER: keycloak
-      MARIADB_PASSWORD: password
-      MARIADB_ROOT_PASSWORD: root
-      MARIADB_DATABASE: keycloak_external
-    ports:
-      - "3306:3306"
-    volumes:
-      - federation-db-data:/var/lib/mysql
-
-  cas-db:
+  adh6-local-db:
     image: mariadb:10.6
     environment:
       MARIADB_USER: casuser
@@ -34,10 +22,10 @@ services:
       - "3307:3306"
     volumes:
       - ./sql:/docker-entrypoint-initdb.d
-      - cas-db-data:/var/lib/mysql
+      - adh6-local-db-data:/var/lib/mysql
 
   keycloak:
-    image: quay.io/keycloak/keycloak:22.0.5
+    image: quay.io/keycloak/keycloak:26.2.5
     command: start-dev
     environment:
       KEYCLOAK_ADMIN: admin
@@ -53,10 +41,8 @@ services:
       - ./target/UserStorageFederation-0.0.1.jar:/opt/keycloak/providers/UserStorageFederation-0.0.1.jar
     depends_on:
       - keycloak-db
-      - federation-db
-      - cas-db
+      - adh6-local-db
 
 volumes:
   keycloak-db-data:
-  federation-db-data:
-  cas-db-data:
+  adh6-local-db-data:

--- a/pom.xml
+++ b/pom.xml
@@ -9,28 +9,22 @@
     <version>0.0.1</version>
 
     <properties>
-        <version.keycloak>22.0.5</version.keycloak>
-        <!-- Keycloak 22 runs on Java 17 so compile the provider for that -->
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <version.keycloak>26.2.5</version.keycloak>
+        <!-- Keycloak 26 runs on Java 21 so compile the provider for that -->
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-server-spi</artifactId>
+            <artifactId>keycloak-services</artifactId>
             <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-server-spi-private</artifactId>
-            <version>${version.keycloak}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-model-legacy</artifactId>
+            <artifactId>keycloak-model-storage</artifactId>
             <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -5,7 +5,7 @@
     <class>net.minet.keycloak.spi.entity.ExternalUser</class>
     <properties>
       <property name="jakarta.persistence.jdbc.driver" value="org.mariadb.jdbc.Driver"/>
-      <property name="jakarta.persistence.jdbc.url" value="jdbc:mariadb://federation-db:3306/keycloak_external"/>
+      <property name="jakarta.persistence.jdbc.url" value="jdbc:mariadb://adh6-local-db:3306/adh6_prod"/>
       <property name="jakarta.persistence.jdbc.user" value="keycloak"/>
       <property name="jakarta.persistence.jdbc.password" value="password"/>
       <property name="hibernate.hbm2ddl.auto" value="update"/>


### PR DESCRIPTION
## Summary
- upgrade Keycloak to 26
- consolidate MariaDB services into `adh6-local-db`
- rename DB service in persistence config
- update docs, build settings and Makefile

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5cc77fc8326a15fc0ac6bdcd0ba