### PR TITLE
Document adding custom JVM options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ sql/cas_schema.sql                     -- SQL schema for the external users
 
    The provider connects to the `adh6-local-db` container using the JPA configuration found in `src/main/resources/META-INF/persistence.xml`.
 
+   To pass additional JVM options to Keycloak, append them to the `JAVA_OPTS_APPEND` variable in `docker-compose.dev.yml`. Example:
+
+   ```yaml
+   JAVA_OPTS_APPEND: "-Dnet.bytebuddy.experimental=true -Dmy.custom.property=value"
+   ```
+
 ## License
 
 Released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,7 +34,7 @@ services:
       KC_DB_URL: jdbc:mariadb://keycloak-db:3306/keycloak
       KC_DB_USERNAME: keycloak
       KC_DB_PASSWORD: password
-      JAVA_OPTS_APPEND: "-Dnet.bytebuddy.experimental=true"
+      JAVA_OPTS_APPEND: "-Dnet.bytebuddy.experimental=true -Dmy.custom.property=value"
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Summary
- add example custom property in `docker-compose.dev.yml`
- document how to extend `JAVA_OPTS_APPEND` in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b51c920788326b079ac405feb5dca