### PR TITLE
Fix Keycloak provider DB connection

### DIFF
--- a/src/main/resources/keycloak-config-source.properties
+++ b/src/main/resources/keycloak-config-source.properties
@@ -1,0 +1,8 @@
+quarkus.datasource.db-kind=mariadb
+quarkus.datasource.username=keycloak
+quarkus.datasource.password=password
+quarkus.datasource.jdbc.url=jdbc:mariadb://adh6-local-db:3306/adh6_prod
+quarkus.datasource.jdbc.driver=org.mariadb.jdbc.Driver
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
+quarkus.hibernate-orm.sql-load-script=no-file
+quarkus.hibernate-orm.database.generation=none


### PR DESCRIPTION
## Summary
- configure Quarkus datasource for the user storage provider

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684b56d02d288326bf1765b993a439ed