### PR TITLE
Fix Quarkus dependencies and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ run-db:
 		-p 3306:3306 mariadb:latest
 
 run-adh6-local-db:
-        docker run -d --name adh6-local-mariadb \
+	docker run -d --name adh6-local-mariadb \
 		-e MARIADB_USER=casuser \
 		-e MARIADB_PASSWORD=caspass \
 		-e MARIADB_ROOT_PASSWORD=root \
@@ -28,8 +28,8 @@ run-keycloak: build
 		quay.io/keycloak/keycloak:$(KEYCLOAK_VERSION) start-dev
 
 clean:
-        docker rm -f federation-mariadb || true
-        docker rm -f adh6-local-mariadb || true
+	docker rm -f federation-mariadb || true
+	docker rm -f adh6-local-mariadb || true
 	rm -rf target
 
 .PHONY: build run-db run-adh6-local-db run-keycloak clean

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,20 @@
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.plugin.version>3.12.1</maven.compiler.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <quarkus.version>3.20.1</quarkus.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>


### PR DESCRIPTION
## Summary
- add Quarkus BOM to manage versions
- fix Makefile commands by using proper TAB separators

## Testing
- `make build` *(fails: Could not download dependencies from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_684b64dce2c88326a824263e469bda73