### PR TITLE
Improve README and fix annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ sql/cas_schema.sql                     -- SQL schema for the external users
    It bundles the MariaDB JDBC driver using the Maven Shade plugin,
    so you can copy it directly into Keycloak's `providers` directory.
 
+   **Note:** the JAR must exist before starting the containers. If it is
+   missing when you run `docker compose`, Docker will try to mount a
+   directory in its place and fail with an error similar to:
+
+   ```
+   Error response from daemon: failed to create task for container: ...
+   Are you trying to mount a directory onto a file (or vice-versa)?
+   ```
+
 2. **Start the development environment**
 
    ```bash

--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderFactory.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderFactory.java
@@ -15,7 +15,7 @@ public class FdpSQLUserStorageProviderFactory implements
 
     public static final String PROVIDER_NAME = "fdp-sql";
 
-    @PersistenceUnit("federation")
+    @PersistenceUnit(unitName = "federation")
     private EntityManagerFactory emf;
 
     @Override


### PR DESCRIPTION
## Summary
- adjust `@PersistenceUnit` annotation for unit name
- clarify README instructions by including the full Docker mount error

## Testing
- `mvn -q -DskipTests package` *(fails: cannot resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b666d8f708326b722b5919c1e5f56