### PR TITLE
Add troubleshooting note and refine shading config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,21 @@ sql/cas_schema.sql                     -- SQL schema for the external users
    To pass additional JVM options to Keycloak, append them to the `JAVA_OPTS_APPEND` variable in `docker-compose.dev.yml`. Example:
 
    ```yaml
-   JAVA_OPTS_APPEND: "-Dnet.bytebuddy.experimental=true -Dmy.custom.property=value"
-   ```
+JAVA_OPTS_APPEND: "-Dnet.bytebuddy.experimental=true -Dmy.custom.property=value"
+```
+
+## Troubleshooting
+
+If Keycloak fails during the `build` phase with an error similar to:
+
+```
+ERROR: io.smallrye.config.ConfigSourceFactory: io.smallrye.config.PropertiesLocationConfigSourceFactory not a subtype
+```
+
+it usually means that the provider JAR contains its own copy of Quarkus libraries.
+To avoid classloading conflicts, ensure the Maven Shade plugin only bundles the
+MariaDB JDBC driver. The provided `pom.xml` already defines this configuration.
+Rebuild the project and copy the resulting JAR to Keycloak's `providers` directory.
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
                 <version>3.5.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <artifactSet>
+                        <includes>
+                            <include>org.mariadb.jdbc:mariadb-java-client</include>
+                        </includes>
+                    </artifactSet>
+                    <minimizeJar>true</minimizeJar>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Summary
- add guidance for resolving "ConfigSourceFactory not a subtype" errors
- ensure shade plugin only bundles the MariaDB JDBC driver

## Testing
- `make build` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b6873726083268e5ef8bad2d361e1