### PR TITLE
Fix XA transaction setting for Keycloak federation datasource

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ quarkus.datasource.federation.username=keycloak
 quarkus.datasource.federation.password=password
 quarkus.datasource.federation.jdbc.url=jdbc:mariadb://adh6-local-db:3306/adh6_prod
 quarkus.datasource.federation.jdbc.driver=org.mariadb.jdbc.Driver
+quarkus.datasource.federation.jdbc.transactions=xa
 
 # Hibernate ORM lié à la datasource 'federation'
 quarkus.hibernate-orm.federation.datasource=federation

--- a/src/main/resources/keycloak-config-source.properties
+++ b/src/main/resources/keycloak-config-source.properties
@@ -3,6 +3,7 @@ quarkus.datasource.username=keycloak
 quarkus.datasource.password=password
 quarkus.datasource.jdbc.url=jdbc:mariadb://adh6-local-db:3306/adh6_prod
 quarkus.datasource.jdbc.driver=org.mariadb.jdbc.Driver
+quarkus.datasource.jdbc.transactions=xa
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.MariaDBDialect
 quarkus.hibernate-orm.sql-load-script=no-file
 quarkus.hibernate-orm.database.generation=none


### PR DESCRIPTION
## Summary
- enable XA transactions for the custom `federation` datasource
- allow Keycloak to run with multiple datasources

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f374b75648326aacade378c97e8ea