### PR TITLE
Add automatic version bump script and pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Pre-commit hook to bump project version
+"$(dirname "$0")/../scripts/bump_version.sh"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 KEYCLOAK_VERSION ?= 26.2.5
-JAR_NAME = UserStorageFederation-0.0.1.jar
+JAR_NAME = UserStorageFederation-0.0.4.jar
 
 build:
 	mvn -DskipTests package

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ src/
 sql/cas_schema.sql                     -- SQL schema for the external users
 ```
 
+## Version bumping
+
+Before each commit the script `scripts/bump_version.sh` automatically
+increments the patch version found in `pom.xml` and updates all references
+to the provider JAR in the repository. The Git hook lives in
+`.githooks/pre-commit`.
+
+Activate it once after cloning:
+
+```bash
+git config core.hooksPath .githooks
+```
+
 ## Getting started
 
 1. **Build the provider**
@@ -29,7 +42,7 @@ sql/cas_schema.sql                     -- SQL schema for the external users
    make build
    ```
 
-   The JAR is created under `target/UserStorageFederation-0.0.1.jar`.
+   The JAR is created under `target/UserStorageFederation-0.0.4.jar`.
    It bundles the MariaDB JDBC driver using the Maven Shade plugin,
    so you can copy it directly into Keycloak's `providers` directory.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,7 +38,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./target/UserStorageFederation-0.0.1.jar:/opt/keycloak/providers/UserStorageFederation-0.0.1.jar
+      - ./target/UserStorageFederation-0.0.4.jar:/opt/keycloak/providers/UserStorageFederation-0.0.4.jar
     depends_on:
       - keycloak-db
       - adh6-local-db

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.minet</groupId>
     <artifactId>UserStorageFederation</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.4</version>
 
     <properties>
         <version.keycloak>26.2.5</version.keycloak>

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine project root (directory of this script's parent)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+POM="pom.xml"
+
+# Extract version from pom.xml using Python for robust XML parsing
+current_version=$(python3 - <<'PY'
+import sys, xml.etree.ElementTree as ET
+try:
+    tree = ET.parse('pom.xml')
+    root = tree.getroot()
+    ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
+    version = root.find('m:version', ns)
+    if version is None or not version.text:
+        raise ValueError('No version element found')
+    print(version.text)
+except Exception as e:
+    sys.exit(f'Error parsing pom.xml: {e}')
+PY
+)
+
+# Validate and bump version
+if [[ "$current_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
+    major="${BASH_REMATCH[1]}"
+    minor="${BASH_REMATCH[2]}"
+    patch="${BASH_REMATCH[3]}"
+    suffix="${BASH_REMATCH[4]}"
+    patch=$((patch + 1))
+    new_version="${major}.${minor}.${patch}${suffix}"
+else
+    echo "Unsupported version format: $current_version" >&2
+    exit 1
+fi
+
+# Replace versions in files
+sed -i "0,/<version>${current_version//\./\.}<\/version>/s//<version>$new_version<\/version>/" "$POM"
+sed -i "s/UserStorageFederation-${current_version//\./\.}.jar/UserStorageFederation-$new_version.jar/g" Makefile docker-compose.dev.yml README.md
+
+echo "Bumped version: $current_version -> $new_version"


### PR DESCRIPTION
## Summary
- add `scripts/bump_version.sh` to increment patch version across project files
- run this script via `.githooks/pre-commit`
- document version bump workflow in README
- updated project version to 0.0.4

## Testing
- `make build` *(fails: Non-resolvable import POM: could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684f4459ad8c8326b502fd1a25c85d0d