### PR TITLE
Disable shade plugin jar minimization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
                             <include>org.mariadb.jdbc:mariadb-java-client</include>
                         </includes>
                     </artifactSet>
-                    <minimizeJar>true</minimizeJar>
+                    <minimizeJar>false</minimizeJar>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Summary
- disable minimizeJar in the maven-shade-plugin configuration

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -DskipTests package` *(fails: Could not transfer artifact quarkus-bom)*

------
https://chatgpt.com/codex/tasks/task_e_684f5a817a5c83269b00a04835de4701