### PR TITLE
Add Postgres container for Keycloak

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0.0
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_DB: postgres
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: keycloak
+      KC_DB_URL_HOST: postgres
+      KC_DB_URL_DATABASE: keycloak
+    command: start-dev
+    depends_on:
+      - postgres
+    ports:
+      - "8080:8080"
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- extend `docker-compose.yml` to include a dedicated Postgres database for Keycloak

## Testing
- `docker-compose --version` *(fails: command not found)*
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5dd259748326bda2172f8e900419