### PR TITLE
Update Keycloak version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FDP User Storage Federation
 
-This module provides a simple Keycloak 26 user storage provider backed by a MariaDB table named `adherents`.
+This module provides a simple Keycloak 26.2.5 user storage provider backed by a MariaDB table named `adherents`.
 The table schema is included in [sql/cas_schema.sql](sql/cas_schema.sql).
 
 Build the provider with Maven and copy the resulting JAR into Keycloak's `providers` directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
   keycloak:
-    image: quay.io/keycloak/keycloak:26.0.0
+    image: quay.io/keycloak/keycloak:26.2.5
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin


### PR DESCRIPTION
## Summary
- use Keycloak `26.2.5` image for development
- update README to mention Keycloak `26.2.5`

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f69a149808326bc560bde462a8407