### PR TITLE
Add MariaDB service

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,9 @@
 This module provides a simple Keycloak 26.2.5 user storage provider backed by a MariaDB table named `adherents`.
 The table schema is included in [sql/cas_schema.sql](sql/cas_schema.sql).
 
+The `docker-compose.yml` file now also provisions a MariaDB service hosting a
+database named `adh6_prod`. The federation provider connects to this database to
+retrieve external users.
+
 Build the provider with Maven and copy the resulting JAR into Keycloak's `providers` directory.
 It exposes the external users to Keycloak and allows authentication against the `adherents` table.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,19 @@ services:
     command: start-dev
     depends_on:
       - postgres
+      - mariadb
     ports:
       - "8080:8080"
+  mariadb:
+    image: mariadb:11
+    environment:
+      MARIADB_DATABASE: adh6_prod
+      MARIADB_USER: keycloak
+      MARIADB_PASSWORD: password
+      MARIADB_ROOT_PASSWORD: root
+    volumes:
+      - mariadb_data:/var/lib/mysql
+      - ./sql:/docker-entrypoint-initdb.d:ro
 volumes:
   postgres_data:
+  mariadb_data:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 quarkus.datasource.federation.db-kind=mariadb
 quarkus.datasource.federation.username=keycloak
 quarkus.datasource.federation.password=password
-quarkus.datasource.federation.jdbc.url=jdbc:mariadb://localhost:3306/adh6_prod
+quarkus.datasource.federation.jdbc.url=jdbc:mariadb://mariadb:3306/adh6_prod
 quarkus.datasource.federation.jdbc.driver=org.mariadb.jdbc.MariaDbXADataSource
 quarkus.datasource.federation.jdbc.transactions=xa
 


### PR DESCRIPTION
## Summary
- add MariaDB service `adh6_prod` to docker-compose
- update datasource URL
- document the new database service

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact io.quarkus:quarkus-bom from https://repo.maven.apache.org/maven2)*

------
https://chatgpt.com/codex/tasks/task_e_684f6c4e23c88326859b9b1dd9d1d971