### PR TITLE
Enable Keycloak federation with MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ The `docker-compose.yml` file now also provisions a MariaDB service hosting a
 database named `adh6_prod`. The federation provider connects to this database to
 retrieve external users.
 
-Build the provider with Maven and copy the resulting JAR into Keycloak's `providers` directory.
-It exposes the external users to Keycloak and allows authentication against the `adherents` table.
+Build the provider with Maven and then start the provided `docker-compose.yml` stack.
+The Keycloak container mounts the built JAR and loads the configuration from `application.properties` so that the federation connects to the MariaDB database.
+External users stored in the `adherents` table can then authenticate through Keycloak.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,20 @@ services:
       KC_DB_PASSWORD: keycloak
       KC_DB_URL_HOST: postgres
       KC_DB_URL_DATABASE: keycloak
+      QUARKUS_DATASOURCE_FEDERATION_JDBC_URL: jdbc:mariadb://mariadb:3306/adh6_prod
+      QUARKUS_DATASOURCE_FEDERATION_USERNAME: keycloak
+      QUARKUS_DATASOURCE_FEDERATION_PASSWORD: password
+      QUARKUS_HIBERNATE_ORM_FEDERATION_DATASOURCE: federation
+      QUARKUS_HIBERNATE_ORM_FEDERATION_DIALECT: org.hibernate.dialect.MariaDBDialect
     command: start-dev
     depends_on:
       - postgres
       - mariadb
     ports:
       - "8080:8080"
+    volumes:
+      - ./target/UserStorageFederation-0.0.1.jar:/opt/keycloak/providers/UserStorageFederation.jar:ro
+      - ./src/main/resources/application.properties:/opt/keycloak/conf/application.properties:ro
   mariadb:
     image: mariadb:11
     environment:

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+  <persistence-unit name="federation">
+    <class>net.minet.keycloak.spi.entity.ExternalUser</class>
+    <properties>
+      <property name="jakarta.persistence.jdbc.driver" value="org.mariadb.jdbc.Driver"/>
+      <property name="jakarta.persistence.jdbc.url" value="jdbc:mariadb://mariadb:3306/adh6_prod"/>
+      <property name="jakarta.persistence.jdbc.user" value="keycloak"/>
+      <property name="jakarta.persistence.jdbc.password" value="password"/>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.MariaDBDialect"/>
+    </properties>
+  </persistence-unit>
+</persistence>

--- a/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
@@ -1,0 +1,1 @@
+net.minet.keycloak.spi.FdpSQLUserStorageProviderFactory


### PR DESCRIPTION
## Summary
- register `FdpSQLUserStorageProviderFactory` using service loader
- configure JPA persistence unit for MariaDB
- mount the provider JAR and configuration in `docker-compose.yml`
- document how to start the stack

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f71223c7483268cc57191a10ecaf4