### PR TITLE
Improve Keycloak startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ To build the federation you need Node.js. The recommended way to install it is w
 Build the provider with Maven and then start the provided `docker-compose.yml` stack.
 The Keycloak container mounts the built JAR and loads the configuration from `application.properties` so that the federation connects to the MariaDB database.
 External users stored in the `adherents` table can then authenticate through Keycloak.
+
+## Optimized Keycloak build
+
+`docker-compose.yml` now runs `kc.sh build` automatically using the `KC_DB`
+environment variable. If you start Keycloak manually, run the following command
+before `start` and replace the vendor as needed:
+
+```bash
+kc.sh build --db=mssql
+```
+
+After building, launch Keycloak with `kc.sh start-dev` or `kc.sh start`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
       QUARKUS_DATASOURCE_FEDERATION_PASSWORD: password
       QUARKUS_HIBERNATE_ORM_FEDERATION_DATASOURCE: federation
       QUARKUS_HIBERNATE_ORM_FEDERATION_DIALECT: org.hibernate.dialect.MariaDBDialect
-    command: start-dev
+    entrypoint: ["sh", "-c"]
+    command: "kc.sh build --db=$KC_DB && exec kc.sh start-dev"
     depends_on:
       - postgres
       - mariadb


### PR DESCRIPTION
## Summary
- auto-build Keycloak with the DB vendor before start in docker-compose
- clarify optimized build instructions

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM due to network issues)*


------
https://chatgpt.com/codex/tasks/task_e_684f89a438048326868bfd7498b3b435