### PR TITLE
Add mariaDB dependencies in Keycloak build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ External users stored in the `adherents` table can then authenticate through Key
 
 `docker-compose.yml` now runs `kc.sh build` automatically using the `KC_DB`
 environment variable. If you start Keycloak manually, run the following command
-before `start` and replace the vendor as needed:
+before `start` and replace the vendor as needed. The additional dependency flag
+downloads the MariaDB JDBC driver from Maven Central during the build:
 
 ```bash
-kc.sh build --db=mssql
+kc.sh build --db=mssql \
+  --spi-connections-jpa-quarkus-additional-dependencies=org.mariadb.jdbc:mariadb-java-client
 ```
 
 After building, launch Keycloak with `kc.sh start-dev` or `kc.sh start`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       QUARKUS_HIBERNATE_ORM_FEDERATION_DATASOURCE: federation
       QUARKUS_HIBERNATE_ORM_FEDERATION_DIALECT: org.hibernate.dialect.MariaDBDialect
     entrypoint: ["sh", "-c"]
-    command: "kc.sh build --db=$KC_DB && exec kc.sh start-dev"
+    command: "kc.sh build --db=$KC_DB --spi-connections-jpa-quarkus-additional-dependencies=org.mariadb.jdbc:mariadb-java-client && exec kc.sh start-dev"
     depends_on:
       - postgres
       - mariadb


### PR DESCRIPTION
## Summary
- add mariaDB JDBC driver as additional dependency during Keycloak build
- document the CLI flag in `README.md`

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f92d72edc83268d6b43476755eb24