### PR TITLE
Set Quarkus to ignore persistence.xml

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,5 @@ quarkus.datasource.federation.jdbc.url=jdbc:mariadb://mariadb:3306/adh6_prod
 quarkus.datasource.federation.jdbc.driver=org.mariadb.jdbc.Driver
 
 quarkus.datasource.devservices=false
+
+quarkus.hibernate-orm.persistence-xml.ignore=true


### PR DESCRIPTION
## Summary
- tell Keycloak to ignore any legacy persistence.xml

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685126de39d48326be6c2e92d019caf3