### PR TITLE
Fix XA configuration for extra datasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ Central.
 ## Optimized Keycloak build
 
 `docker-compose.yml` now runs `kc.sh build` automatically using the `KC_DB`
-environment variable. If you start Keycloak manually, run the following command
-before `start` and replace the vendor as needed. The additional CLI option tells
-Keycloak to download the MariaDB JDBC driver from Maven Central during the
-build:
+environment variable. Keycloak 26 requires XA transactions when more than one
+datasource is configured. The compose file enables them automatically, but if
+you start Keycloak manually, run the following command before `start` and
+replace the vendor as needed. The additional CLI options tell Keycloak to
+download the MariaDB JDBC driver from Maven Central and enable XA transactions
+for the default datasource during the build:
 
 ```bash
-kc.sh build --db=mssql \
+kc.sh build --db=mssql --transaction-xa-enabled=true \
   --spi-connections-jpa-quarkus-additional-dependencies=org.mariadb.jdbc:mariadb-java-client
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       QUARKUS_HIBERNATE_ORM_FEDERATION_DIALECT: org.hibernate.dialect.MariaDBDialect
     entrypoint: ["sh", "-c"]
     command: >
-      kc.sh build --db=$KC_DB
+      kc.sh build --db=$KC_DB --transaction-xa-enabled=true
         --spi-connections-jpa-quarkus-additional-dependencies=org.mariadb.jdbc:mariadb-java-client
         && exec kc.sh start-dev
     depends_on:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ quarkus.datasource.federation.username=keycloak
 quarkus.datasource.federation.password=password
 quarkus.datasource.federation.jdbc.url=jdbc:mariadb://mariadb:3306/adh6_prod
 quarkus.datasource.federation.jdbc.driver=org.mariadb.jdbc.Driver
+quarkus.datasource.federation.jdbc.transactions=xa
 
 quarkus.datasource.devservices=false
 


### PR DESCRIPTION
## Summary
- enable XA transactions for the federation datasource
- run Keycloak build with `--transaction-xa-enabled=true`
- document the extra build option in README

## Testing
- `apt-get install -y maven`
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68512c481574832682d31f81841f8dd2