### PR TITLE
Add Dockerfile to build Keycloak image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Multi-stage build for Keycloak with FDP federation provider
+
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+WORKDIR /build
+COPY pom.xml .
+COPY src ./src
+RUN mvn -B package
+
+FROM eclipse-temurin:21-jdk AS keycloak
+ARG KEYCLOAK_VERSION=26.2.5
+ENV KC_HOME=/opt/keycloak
+RUN curl -fsSLo /tmp/keycloak.tar.gz https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-${KEYCLOAK_VERSION}.tar.gz \
+    && mkdir -p ${KC_HOME} \
+    && tar -xzf /tmp/keycloak.tar.gz --strip-components=1 -C ${KC_HOME} \
+    && rm /tmp/keycloak.tar.gz
+ENV PATH="${KC_HOME}/bin:${PATH}"
+COPY --from=builder /build/target/UserStorageFederation-0.0.1.jar ${KC_HOME}/providers/UserStorageFederation.jar
+COPY src/main/resources/application.properties ${KC_HOME}/conf/application.properties
+RUN kc.sh build --spi-connections-jpa-quarkus-additional-dependencies=org.mariadb.jdbc:mariadb-java-client
+
+EXPOSE 8080
+ENTRYPOINT ["kc.sh"]
+CMD ["start-dev"]

--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ kc.sh build --db=mssql --transaction-xa-enabled=true \
 ```
 
 After building, launch Keycloak with `kc.sh start-dev` or `kc.sh start`.
+
+## Docker image
+
+A `Dockerfile` is provided to build Keycloak with the federation provider included. It downloads Keycloak 26.2.5, copies the built JAR and `application.properties`, then runs `kc.sh build` to fetch the MariaDB driver.
+
+Build the image and run it locally:
+
+```bash
+docker build -t custom-keycloak .
+docker run --rm -p 8080:8080 custom-keycloak
+```

--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 This module provides a simple Keycloak 26.2.5 user storage provider backed by a MariaDB table named `adherents`.
 The table schema is included in [sql/cas_schema.sql](sql/cas_schema.sql).
 
-The `docker-compose.yml` file now also provisions a MariaDB service hosting a
-database named `adh6_prod`. The federation provider connects to this database to
-retrieve external users.
-To build the federation you need Node.js. The recommended way to install it is with [nvm](https://github.com/nvm-sh/nvm).
+The `docker-compose.yml` file provisions Keycloak, PostgreSQL and a MariaDB
+instance hosting a database named `adh6_prod` that stores external users.
+To build the federation you need Node.js. The recommended way to install it is
+with [nvm](https://github.com/nvm-sh/nvm).
 
-Build the provider with Maven and then start the provided `docker-compose.yml` stack.
-The Keycloak container mounts the built JAR and loads the configuration from `application.properties` so that the federation connects to the MariaDB database.
-External users stored in the `adherents` table can then authenticate through Keycloak.
+Build the provider with Maven and then use `docker compose up --build` to build
+the custom Keycloak image and start the stack. The provider JAR and
+`application.properties` are copied into the image so no extra volumes are
+required. External users stored in the `adherents` table can then authenticate
+through Keycloak.
 
 When building Keycloak, ensure that the MariaDB JDBC driver is available. The
 included compose file passes the
@@ -20,13 +22,13 @@ Central.
 
 ## Optimized Keycloak build
 
-`docker-compose.yml` now runs `kc.sh build` automatically using the `KC_DB`
-environment variable. Keycloak 26 requires XA transactions when more than one
-datasource is configured. The compose file enables them automatically, but if
-you start Keycloak manually, run the following command before `start` and
-replace the vendor as needed. The additional CLI options tell Keycloak to
-download the MariaDB JDBC driver from Maven Central and enable XA transactions
-for the default datasource during the build:
+The Dockerfile invokes `kc.sh build` so the MariaDB driver is downloaded
+automatically. Keycloak 26 requires XA transactions when more than one
+datasource is configured. If you start Keycloak manually instead of using the
+provided image, run the following command before `start` and replace the vendor
+as needed. The additional CLI options tell Keycloak to download the MariaDB JDBC
+driver from Maven Central and enable XA transactions for the default datasource
+during the build:
 
 ```bash
 kc.sh build --db=mssql --transaction-xa-enabled=true \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
   keycloak:
-    image: quay.io/keycloak/keycloak:26.2.5
+    build: .
+    image: custom-keycloak
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
@@ -29,9 +30,6 @@ services:
       - mariadb
     ports:
       - "8080:8080"
-    volumes:
-      - ./target/UserStorageFederation-0.0.1.jar:/opt/keycloak/providers/UserStorageFederation.jar:ro
-      - ./src/main/resources/application.properties:/opt/keycloak/conf/application.properties:ro
   mariadb:
     image: mariadb:11
     environment:


### PR DESCRIPTION
## Summary
- add Dockerfile that builds Keycloak from distribution and installs the user storage provider
- document the new Docker image in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852b064706883268e27fcfd11298c1d