### PR TITLE
Avoid building UserFederation during compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-# Multi-stage build for Keycloak with FDP federation provider
-
-FROM maven:3.9.6-eclipse-temurin-21 AS builder
-WORKDIR /build
-COPY pom.xml .
-COPY src ./src
-RUN mvn -B package
+# Keycloak image with FDP federation provider
 
 FROM eclipse-temurin:21-jdk AS keycloak
 ARG KEYCLOAK_VERSION=26.2.5
@@ -14,7 +8,7 @@ RUN curl -fsSLo /tmp/keycloak.tar.gz https://github.com/keycloak/keycloak/releas
     && tar -xzf /tmp/keycloak.tar.gz --strip-components=1 -C ${KC_HOME} \
     && rm /tmp/keycloak.tar.gz
 ENV PATH="${KC_HOME}/bin:${PATH}"
-COPY --from=builder /build/target/UserStorageFederation-0.0.1.jar ${KC_HOME}/providers/UserStorageFederation.jar
+COPY target/UserStorageFederation-0.0.1.jar ${KC_HOME}/providers/UserStorageFederation.jar
 COPY src/main/resources/application.properties ${KC_HOME}/conf/application.properties
 RUN kc.sh build --spi-connections-jpa-quarkus-additional-dependencies=org.mariadb.jdbc:mariadb-java-client
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ instance hosting a database named `adh6_prod` that stores external users.
 To build the federation you need Node.js. The recommended way to install it is
 with [nvm](https://github.com/nvm-sh/nvm).
 
-Build the provider with Maven and then use `docker compose up --build` to build
-the custom Keycloak image and start the stack. The provider JAR and
+Build the provider with Maven and build the custom Keycloak image manually with
+`docker build -t custom-keycloak .`. Once the image is available locally, start
+the stack with `docker compose up`. The provider JAR and
 `application.properties` are copied into the image so no extra volumes are
 required. External users stored in the `adherents` table can then authenticate
 through Keycloak.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
   keycloak:
-    build: .
     image: custom-keycloak
     environment:
       KEYCLOAK_ADMIN: admin


### PR DESCRIPTION
## Summary
- remove the Maven build stage from the Dockerfile
- expect `target/UserStorageFederation-0.0.1.jar` to exist locally
- stop building the image in `docker-compose.yml`
- update docs for the manual image build step

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6852b2c310708326b9db4bc301511c09