### PR TITLE
Use XA datasource for federation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,12 @@ services:
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      # Use XA transactions for the default datasource
       QUARKUS_DATASOURCE_JDBC_TRANSACTIONS: xa
       QUARKUS_DATASOURCE_FEDERATION_JDBC_URL: jdbc:mariadb://mariadb:3306/adh6_prod
       QUARKUS_DATASOURCE_FEDERATION_USERNAME: keycloak
       QUARKUS_DATASOURCE_FEDERATION_PASSWORD: password
-      QUARKUS_DATASOURCE_FEDERATION_JDBC_TRANSACTIONS: enabled
+      QUARKUS_DATASOURCE_FEDERATION_JDBC_TRANSACTIONS: xa
       QUARKUS_HIBERNATE_ORM_FEDERATION_DATASOURCE: federation
       QUARKUS_HIBERNATE_ORM_FEDERATION_DIALECT: org.hibernate.dialect.MariaDBDialect
     command: start-dev

--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderFactory.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderFactory.java
@@ -1,6 +1,6 @@
 package net.minet.keycloak.spi;
 
-import org.mariadb.jdbc.MariaDbPoolDataSource;
+import org.mariadb.jdbc.MariaDbXADataSource;
 import javax.sql.DataSource;
 import org.keycloak.Config;
 import org.keycloak.component.ComponentModel;
@@ -15,7 +15,7 @@ public class FdpSQLUserStorageProviderFactory implements UserStorageProviderFact
     @Override
     public void init(Config.Scope config) {
         try {
-            MariaDbPoolDataSource ds = new MariaDbPoolDataSource();
+            MariaDbXADataSource ds = new MariaDbXADataSource();
             ds.setUrl(System.getProperty("quarkus.datasource.federation.jdbc.url",
                     System.getenv("QUARKUS_DATASOURCE_FEDERATION_JDBC_URL")));
             ds.setUser(System.getProperty("quarkus.datasource.federation.username",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,5 +3,4 @@ quarkus.datasource.federation.db-kind=mariadb
 quarkus.datasource.federation.username=keycloak
 quarkus.datasource.federation.password=password
 quarkus.datasource.federation.jdbc.url=jdbc:mariadb://mariadb:3306/adh6_prod
-quarkus.datasource.federation.jdbc.driver=org.mariadb.jdbc.Driver
-quarkus.datasource.federation.jdbc.transactions=enabled
+quarkus.datasource.federation.jdbc.transactions=xa


### PR DESCRIPTION
## Summary
- use `MariaDbXADataSource` directly in the provider
- clean up redundant driver configuration in `docker-compose.yml` and `application.properties`

## Testing
- `apt-get update`
- `apt-get install -y maven libmariadb-java`
- `mvn -q dependency:get -Dartifact=org.mariadb.jdbc:mariadb-java-client:3.5.1` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852d2884b38832690962db05129e779