### PR TITLE
Fix missing MariaDbXADataSource

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbXADataSource.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbXADataSource.java
@@ -1,0 +1,16 @@
+package org.mariadb.jdbc;
+
+/**
+ * Compatibility wrapper for {@link MariaDbDataSource} implementing the deprecated
+ * {@code MariaDbXADataSource} name used by older code.
+ */
+public class MariaDbXADataSource extends MariaDbDataSource {
+
+    public MariaDbXADataSource() {
+        super();
+    }
+
+    public MariaDbXADataSource(String url) throws java.sql.SQLException {
+        super(url);
+    }
+}


### PR DESCRIPTION
## Summary
- revert to MariaDbXADataSource usage
- provide local MariaDbXADataSource shim extending MariaDbDataSource

## Testing
- `mvn -DskipTests compile`


------
https://chatgpt.com/codex/tasks/task_e_6852da0edc608326b20140d52dcc1942