### PR TITLE
Expose ldapLogin in user federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ stored in the `adherents` table can then authenticate through Keycloak.
 The shaded JAR already embeds the MariaDB JDBC driver so no additional build
 options are necessary.
 
+The provider also exposes the `ldap_login` column as a `ldapLogin` attribute on
+Keycloak user profiles. This attribute can be read and updated through the
+standard user attribute APIs.
+
 This provider performs direct SQL queries through JDBC and does not use JPA.
 The plugin can therefore operate without JPA. A complete `persistence.xml`
 showing a typical Hibernate configuration is provided under `META-INF/services`

--- a/sql/cas_data.sql
+++ b/sql/cas_data.sql
@@ -1,3 +1,3 @@
-INSERT INTO adherents (id, nom, prenom, mail, login, password) VALUES
-  (1, 'Dupont', 'Jean', 'jean.dupont@example.com', 'jdupont', 'b39a61f16a4e11fa80580241f1d4aae8'),
-  (2, 'Martin', 'Marie', 'marie.martin@example.com', 'mmartin', 'c2cc78ba8b1df908f563858b3095c7c7');
+INSERT INTO adherents (id, nom, prenom, mail, login, password, ldap_login) VALUES
+  (1, 'Dupont', 'Jean', 'jean.dupont@example.com', 'jdupont', 'b39a61f16a4e11fa80580241f1d4aae8', 'ldap_jdupont'),
+  (2, 'Martin', 'Marie', 'marie.martin@example.com', 'mmartin', 'c2cc78ba8b1df908f563858b3095c7c7', 'ldap_mmartin');


### PR DESCRIPTION
## Summary
- map `ldap_login` column from the database
- expose the value as `ldapLogin` user attribute
- update sample data and documentation

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not download dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6853f5c7ec808326bb774530a3521026