### PR TITLE
Add deprecation note for XA data source

### DIFF
--- a/src/main/java/org/mariadb/jdbc/MariaDbXADataSource.java
+++ b/src/main/java/org/mariadb/jdbc/MariaDbXADataSource.java
@@ -1,8 +1,9 @@
 package org.mariadb.jdbc;
 
 /**
- * Compatibility wrapper for {@link MariaDbDataSource} implementing the deprecated
- * {@code MariaDbXADataSource} name used by older code.
+ * Shim for legacy configuration.
+ * This class exists only for backwards compatibility and may be removed in a
+ * future release. Use {@link MariaDbDataSource} instead.
  */
 public class MariaDbXADataSource extends MariaDbDataSource {
 


### PR DESCRIPTION
## Summary
- clarify that `MariaDbXADataSource` is a legacy shim
- reference `MariaDbDataSource` as the replacement

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685424f529308326ab39c72a1d1bf436