### PR TITLE
Add documentation for Keycloak classes

### DIFF
--- a/src/main/java/net/minet/keycloak/hash/Md4Utf16PasswordHashProvider.java
+++ b/src/main/java/net/minet/keycloak/hash/Md4Utf16PasswordHashProvider.java
@@ -9,6 +9,10 @@ import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.models.PasswordPolicy;
 import org.keycloak.models.credential.PasswordCredentialModel;
 
+/**
+ * Password hash provider that computes an MD4 digest of the UTF-16 encoded
+ * password. Used to verify passwords from legacy systems.
+ */
 public class Md4Utf16PasswordHashProvider implements PasswordHashProvider {
     public static final String ID = "md4-utf16";
     private final int defaultIterations;

--- a/src/main/java/net/minet/keycloak/hash/Md4Utf16PasswordHashProviderFactory.java
+++ b/src/main/java/net/minet/keycloak/hash/Md4Utf16PasswordHashProviderFactory.java
@@ -6,6 +6,9 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.credential.hash.PasswordHashProviderFactory;
 
+/**
+ * Factory that supplies {@link Md4Utf16PasswordHashProvider} to Keycloak.
+ */
 public class Md4Utf16PasswordHashProviderFactory implements PasswordHashProviderFactory {
     @Override
     public PasswordHashProvider create(KeycloakSession session) {

--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
@@ -24,6 +24,10 @@ import org.keycloak.storage.user.UserRegistrationProvider;
 import java.util.Map;
 import java.util.stream.Stream;
 
+/**
+ * User storage provider backed by an external SQL database. It exposes users
+ * to Keycloak and supports credential validation and updates.
+ */
 public class FdpSQLUserStorageProvider implements
         UserStorageProvider,
         UserLookupProvider,

--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderFactory.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderFactory.java
@@ -7,6 +7,10 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.storage.UserStorageProviderFactory;
 
+/**
+ * Factory that creates {@link FdpSQLUserStorageProvider} instances and
+ * initializes the SQL datasource.
+ */
 public class FdpSQLUserStorageProviderFactory implements UserStorageProviderFactory<FdpSQLUserStorageProvider> {
     public static final String PROVIDER_NAME = "fdp-sql";
 

--- a/src/main/java/net/minet/keycloak/spi/entity/ExternalUser.java
+++ b/src/main/java/net/minet/keycloak/spi/entity/ExternalUser.java
@@ -3,6 +3,9 @@ package net.minet.keycloak.spi.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+/**
+ * Simple data object representing a user record in the external SQL database.
+ */
 public class ExternalUser {
     private Integer id;
 


### PR DESCRIPTION
## Summary
- describe provider classes in net.minet.keycloak
- document password hash provider and factory
- document ExternalUser entity

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854252324c883269a77832d35affe87