### PR TITLE
Add tests with JUnit and H2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,37 @@
             <artifactId>quarkus-jdbc-mariadb</artifactId>
             <version>3.20.1</version>
         </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.78.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -59,6 +90,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/net/minet/keycloak/hash/Md4Utf16PasswordHashProviderTest.java
+++ b/src/test/java/net/minet/keycloak/hash/Md4Utf16PasswordHashProviderTest.java
@@ -1,0 +1,20 @@
+import net.minet.keycloak.hash.Md4Utf16PasswordHashProvider;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.credential.PasswordCredentialModel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Md4Utf16PasswordHashProviderTest {
+
+    @Test
+    public void testEncodeAndVerify() {
+        Md4Utf16PasswordHashProvider provider = new Md4Utf16PasswordHashProvider(1);
+        String raw = "password";
+        String hash = provider.encode(raw, 1);
+        assertEquals("8846f7eaee8fb117ad06bdd830b7586c", hash);
+
+        PasswordCredentialModel cred = provider.encodedCredential(raw, 1);
+        assertTrue(provider.verify(raw, cred));
+        assertFalse(provider.verify("wrong", cred));
+    }
+}

--- a/src/test/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderTest.java
+++ b/src/test/java/net/minet/keycloak/spi/FdpSQLUserStorageProviderTest.java
@@ -1,0 +1,43 @@
+import net.minet.keycloak.spi.FdpSQLUserStorageProvider;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.mockito.Mockito;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FdpSQLUserStorageProviderTest {
+
+    private DataSource ds;
+
+    @BeforeEach
+    public void setupDb() throws Exception {
+        JdbcDataSource h2 = new JdbcDataSource();
+        h2.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        ds = h2;
+        try (Connection c = ds.getConnection(); Statement st = c.createStatement()) {
+            st.execute("CREATE TABLE adherents (id INT AUTO_INCREMENT PRIMARY KEY, nom VARCHAR(50), prenom VARCHAR(50), mail VARCHAR(50), login VARCHAR(50), password VARCHAR(64), ldap_login VARCHAR(50))");
+            st.execute("INSERT INTO adherents (nom, prenom, mail, login, password, ldap_login) VALUES ('Doe', 'John', 'john@example.com', 'jdoe', 'pass', 'jdoe')");
+        }
+    }
+
+    @Test
+    public void testGetUserByUsername() {
+        KeycloakSession session = Mockito.mock(KeycloakSession.class);
+        ComponentModel model = Mockito.mock(ComponentModel.class);
+        RealmModel realm = Mockito.mock(RealmModel.class);
+        FdpSQLUserStorageProvider provider = new FdpSQLUserStorageProvider(session, model, ds);
+        UserModel user = provider.getUserByUsername(realm, "jdoe");
+        assertNotNull(user);
+        assertEquals("jdoe", user.getUsername());
+        assertEquals("john@example.com", user.getEmail());
+    }
+}


### PR DESCRIPTION
## Summary
- configure JUnit 5 test framework in `pom.xml`
- add password hash provider test
- add SQL provider test with H2 in‑memory DB

## Testing
- `mvn test` *(fails: Network is unreachable while downloading Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685424ed1c048326ac1f5a517fe898f8