### PR TITLE
Refactor MD4 hashing into utility and add tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>quarkus-jdbc-mariadb</artifactId>
             <version>3.20.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -81,6 +87,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/net/minet/keycloak/hash/Md4Utf16PasswordHashProvider.java
+++ b/src/main/java/net/minet/keycloak/hash/Md4Utf16PasswordHashProvider.java
@@ -1,9 +1,6 @@
 package net.minet.keycloak.hash;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
+import net.minet.keycloak.hash.Md4Util;
 
 import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.models.PasswordPolicy;
@@ -34,13 +31,7 @@ public class Md4Utf16PasswordHashProvider implements PasswordHashProvider {
 
     @Override
     public String encode(String rawPassword, int iterations) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("MD4");
-            byte[] digest = md.digest(rawPassword.getBytes(StandardCharsets.UTF_16LE));
-            return HexFormat.of().formatHex(digest);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("MD4 algorithm not available", e);
-        }
+        return Md4Util.md4Hex(rawPassword);
     }
 
     @Override

--- a/src/main/java/net/minet/keycloak/hash/Md4Util.java
+++ b/src/main/java/net/minet/keycloak/hash/Md4Util.java
@@ -1,0 +1,26 @@
+package net.minet.keycloak.hash;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/** Utility for computing MD4 digests as hexadecimal strings. */
+public final class Md4Util {
+    private Md4Util() {
+    }
+
+    /**
+     * Returns the MD4 hash of the given input encoded in UTF-16LE as a
+     * lower-case hexadecimal string.
+     */
+    public static String md4Hex(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD4");
+            byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_16LE));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("MD4 algorithm not available", e);
+        }
+    }
+}

--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
@@ -2,10 +2,7 @@ package net.minet.keycloak.spi;
 
 import javax.sql.DataSource;
 import java.sql.*;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.HexFormat;
+import net.minet.keycloak.hash.Md4Util;
 import net.minet.keycloak.spi.entity.ExternalUser;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.credential.CredentialInput;
@@ -128,7 +125,7 @@ public class FdpSQLUserStorageProvider implements
         if (!supportsCredentialType(input.getType())) return false;
         try (Connection c = dataSource.getConnection();
              PreparedStatement ps = c.prepareStatement("UPDATE adherents SET password = ? WHERE id = ?")) {
-            ps.setString(1, md4Hex(input.getChallengeResponse()));
+            ps.setString(1, Md4Util.md4Hex(input.getChallengeResponse()));
             ps.setInt(2, Integer.parseInt(user.getId()));
             return ps.executeUpdate() > 0;
         } catch (SQLException e) {
@@ -159,7 +156,7 @@ public class FdpSQLUserStorageProvider implements
             ps.setInt(1, Integer.parseInt(user.getId()));
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    return md4Hex(input.getChallengeResponse()).equalsIgnoreCase(rs.getString(1));
+                    return Md4Util.md4Hex(input.getChallengeResponse()).equalsIgnoreCase(rs.getString(1));
                 }
             }
         } catch (SQLException e) {
@@ -265,15 +262,6 @@ public class FdpSQLUserStorageProvider implements
         return Stream.empty();
     }
 
-    private String md4Hex(String input) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("MD4");
-            byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_16LE));
-            return HexFormat.of().formatHex(digest);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("MD4 algorithm not available", e);
-        }
-    }
 
     private static class ExternalUserAdapter extends AbstractUserAdapterFederatedStorage {
         private final ExternalUser user;

--- a/src/test/java/net/minet/keycloak/hash/Md4UtilTest.java
+++ b/src/test/java/net/minet/keycloak/hash/Md4UtilTest.java
@@ -1,0 +1,14 @@
+package net.minet.keycloak.hash;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class Md4UtilTest {
+    @Test
+    void computesMd4HexCorrectly() {
+        assertEquals("8846f7eaee8fb117ad06bdd830b7586c", Md4Util.md4Hex("password"));
+        assertEquals("209c6174da490caeb422f3fa5a7ae634", Md4Util.md4Hex("admin"));
+        assertEquals("31d6cfe0d16ae931b73c59d7e0c089c0", Md4Util.md4Hex(""));
+    }
+}


### PR DESCRIPTION
## Summary
- add `Md4Util` with reusable `md4Hex` helper
- refactor password and SQL providers to use `Md4Util`
- add JUnit tests for `Md4Util`
- include JUnit and surefire in Maven build

## Testing
- `mvn -q test` *(fails: unable to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685424e62bec832699c322d505d31514