### PR TITLE
Fix call to removed userLocalStorage method

### DIFF
--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
@@ -19,6 +19,7 @@ import org.keycloak.storage.adapter.AbstractUserAdapterFederatedStorage;
 import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserQueryProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
+import org.keycloak.storage.UserStoragePrivateUtil;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -98,7 +99,8 @@ public class FdpSQLUserStorageProvider implements
         try {
             userId = extractUserId(id);
         } catch (NumberFormatException nfe) {
-            UserModel local = session.userLocalStorage().getUserById(realm, id);
+            UserModel local = UserStoragePrivateUtil.userLocalStorage(session)
+                    .getUserById(realm, id);
             if (local != null) {
                 return getUserByUsername(realm, local.getUsername());
             }


### PR DESCRIPTION
## Summary
- replace deprecated `session.userLocalStorage()` with `UserStoragePrivateUtil.userLocalStorage()`

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM - network unreachable)*
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6856daefa7a883268a0f75b8569be6f2