### PR TITLE
Expose standard user attributes

### DIFF
--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
@@ -317,6 +317,19 @@ public class FdpSQLUserStorageProvider implements
             super(session, realm, model);
             this.user = user;
             this.storageId = new org.keycloak.storage.StorageId(model.getId(), String.valueOf(user.getId()));
+            this.addDefaults();
+        }
+
+        private void addDefaults() {
+            if (user.getEmail() != null) {
+                setEmail(user.getEmail());
+            }
+            if (user.getFirstName() != null) {
+                setFirstName(user.getFirstName());
+            }
+            if (user.getLastName() != null) {
+                setLastName(user.getLastName());
+            }
         }
 
         @Override


### PR DESCRIPTION
## Summary
- mark user attributes as Keycloak defaults in `ExternalUserAdapter`

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68570795b95c8326bc15b34a005531ff