### PR TITLE
Update login logo and locale support

### DIFF
--- a/themes/keywind/login/components/atoms/logo.ftl
+++ b/themes/keywind/login/components/atoms/logo.ftl
@@ -1,5 +1,12 @@
 <#macro kw>
-  <div class="font-bold text-center text-2xl">
-    <#nested>
+  <div class="text-center">
+    <img
+      alt="Logo"
+      class="mx-auto mb-2 h-12"
+      src="https://formation.minet.net/minetLogo.png"
+    />
+    <div class="font-bold text-2xl">
+      <#nested>
+    </div>
   </div>
 </#macro>

--- a/themes/keywind/login/components/molecules/identity-provider.ftl
+++ b/themes/keywind/login/components/molecules/identity-provider.ftl
@@ -1,9 +1,11 @@
 <#import "/assets/providers/providers.ftl" as providerIcons>
 
 <#macro kw providers=[]>
-  <div class="pt-4 separate text-secondary-600 text-sm">
-    ${msg("identity-provider-login-label")}
-  </div>
+  <#if msg("identity-provider-login-label")?has_content>
+    <div class="pt-4 separate text-secondary-600 text-sm">
+      ${msg("identity-provider-login-label")}
+    </div>
+  </#if>
   <div class="gap-4 grid grid-cols-3">
     <#list providers as provider>
       <#switch provider.alias>

--- a/themes/keywind/login/messages/messages_en.properties
+++ b/themes/keywind/login/messages/messages_en.properties
@@ -1,0 +1,1 @@
+identity-provider-login-label=

--- a/themes/keywind/login/messages/messages_fr.properties
+++ b/themes/keywind/login/messages/messages_fr.properties
@@ -1,0 +1,1 @@
+identity-provider-login-label=

--- a/themes/keywind/login/theme.properties
+++ b/themes/keywind/login/theme.properties
@@ -2,3 +2,4 @@ parent=base
 
 styles=dist/index.css
 scripts=dist/index.js
+locales=en,fr


### PR DESCRIPTION
## Summary
- load custom image logo in Keywind theme
- hide identity provider label when untranslated
- provide empty translation key for identity provider label in English and French
- enable French locale in Keywind theme

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6858a1e88c5883268fa1b9e3583ff3b0