### PR TITLE
Fix SQLException handling in ExternalUserMapper

### DIFF
--- a/src/main/java/net/minet/keycloak/spi/ExternalUserMapper.java
+++ b/src/main/java/net/minet/keycloak/spi/ExternalUserMapper.java
@@ -66,9 +66,11 @@ public final class ExternalUserMapper {
 
     private static Set<String> availableColumns(ResultSet rs) throws SQLException {
         ResultSetMetaData meta = rs.getMetaData();
-        return IntStream.rangeClosed(1, meta.getColumnCount())
-                .mapToObj(i -> meta.getColumnLabel(i).toLowerCase())
-                .collect(Collectors.toSet());
+        Set<String> columns = new java.util.HashSet<>();
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            columns.add(meta.getColumnLabel(i).toLowerCase());
+        }
+        return columns;
     }
 
     public static ExternalUser map(ResultSet rs) throws SQLException {


### PR DESCRIPTION
## Summary
- fix compilation error in `ExternalUserMapper.availableColumns` by avoiding a lambda that threw `SQLException`

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685c052c56cc832680253495da73a60e