### PR TITLE
Persist user metadata to SQL store

### DIFF
--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
@@ -57,7 +57,7 @@ public class FdpSQLUserStorageProvider implements
     }
 
     protected UserModel createAdapter(RealmModel realm, ExternalUser user) {
-        return new ExternalUserAdapter(session, realm, model, user);
+        return new ExternalUserAdapter(session, realm, model, user, dataSource);
     }
 
 


### PR DESCRIPTION
## Summary
- persist user attribute updates to external database
- inject DataSource into `ExternalUserAdapter` and update `createAdapter`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_686b77c40224832687ddf4f5d1cd497f