### PR TITLE
Fix user metadata loading

### DIFF
--- a/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
+++ b/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
@@ -149,9 +149,17 @@ public class ExternalUserAdapter extends AbstractUserAdapterFederatedStorage {
     }
 
     private void addDefaults() {
-        if (user.getEmail() != null) setEmail(user.getEmail());
-        if (user.getFirstName() != null) setFirstName(user.getFirstName());
-        if (user.getLastName() != null) setLastName(user.getLastName());
+        ATTR_GETTERS.forEach((name, fn) -> {
+            Object val = fn.apply(user);
+            if (val != null) {
+                switch (name) {
+                    case "email" -> setEmail((String) val);
+                    case "firstName" -> setFirstName((String) val);
+                    case "lastName" -> setLastName((String) val);
+                    default -> updateAttribute(name, val);
+                }
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
## Summary
- load all external user metadata as attributes on adapter construction

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686b7a9237bc8326b9a0bbcef8704755