### PR TITLE
Set created timestamp from database

### DIFF
--- a/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
+++ b/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
@@ -156,6 +156,12 @@ public class ExternalUserAdapter extends AbstractUserAdapterFederatedStorage {
                     case "email" -> setEmail((String) val);
                     case "firstName" -> setFirstName((String) val);
                     case "lastName" -> setLastName((String) val);
+                    case "createdAt" -> {
+                        setCreatedTimestamp(((java.time.LocalDateTime) val)
+                                .atZone(java.time.ZoneId.systemDefault())
+                                .toInstant().toEpochMilli());
+                        updateAttribute(name, val);
+                    }
                     default -> updateAttribute(name, val);
                 }
             }


### PR DESCRIPTION
## Summary
- map `createdAt` to Keycloak created timestamp while keeping attribute

## Testing
- `mvn -q package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686b7f4c4cf48326b2c7ca4016a10c94