### PR TITLE
Fix account theme inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker compose -f docker-compose.prod.yml up
 
 This repository bundles the [Keywind](https://github.com/lukin/keywind) login theme under `themes/keywind`. Only the templates required for signing in and changing a password are included. Both development and production Compose files mount this directory into Keycloak so you can select the `keywind` theme in the administration console.
 
-An account theme with the same styling is provided in `themes/keywind/account`. Mounting this directory lets Keycloak render the account console with the Minet look and feel.
+An account theme with the same styling is provided in `themes/keywind/account`. Mounting this directory lets Keycloak render the account console with the Minet look and feel. It inherits from the default `keycloak` account theme so only the CSS and JavaScript assets are overridden.
 
 ## 📝 Logging
 

--- a/themes/keywind/account/theme.properties
+++ b/themes/keywind/account/theme.properties
@@ -1,4 +1,4 @@
-parent=base
+parent=keycloak
 styles=dist/index.css
 scripts=dist/index.js
 locales=en,fr


### PR DESCRIPTION
## Summary
- inherit from the default `keycloak` account theme so Keycloak can render the account console
- document the account theme's parent in the README

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686b7fd2cd448326b1c3dd238bf381fa