### PR TITLE
Add user profile config

### DIFF
--- a/conf/user-profile.json
+++ b/conf/user-profile.json
@@ -1,0 +1,155 @@
+{
+    "attributes": [
+        {
+            "name": "ldapLogin",
+            "displayName": "LDAP login",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "general",
+            "displayName": "Comments",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "departureDate",
+            "displayName": "Departure date",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "modeAssociation",
+            "displayName": "Mode association",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "accessToken",
+            "displayName": "Access token",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "subnet",
+            "displayName": "Subnet",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "ip",
+            "displayName": "IP address",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "chambreId",
+            "displayName": "Chambre ID",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "createdAt",
+            "displayName": "Created at (DB)",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "updatedAt",
+            "displayName": "Updated at (DB)",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "edminet",
+            "displayName": "Edminet",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "isNaina",
+            "displayName": "Is Naina",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "mailingList",
+            "displayName": "Mailing list",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "mailMembership",
+            "displayName": "Mail membership",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "dateSignedHosting",
+            "displayName": "Date signed hosting",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "dateSignedAdhesion",
+            "displayName": "Date signed adhesion",
+            "group": "external",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        }
+    ],
+    "groups": [
+        {
+            "name": "external",
+            "displayHeader": "External Attributes",
+            "displayDescription": "Attributes from the external database"
+        }
+    ]
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,11 +14,13 @@ services:
       QUARKUS_DATASOURCE_FEDERATION_PASSWORD: password
       QUARKUS_DATASOURCE_FEDERATION_JDBC_DRIVER: org.mariadb.jdbc.MariaDbDataSource
       QUARKUS_DATASOURCE_FEDERATION_JDBC_TRANSACTIONS: xa
+      KC_SPI_USER_PROFILE_DECLARATIVE_USER_PROFILE_CONFIG_FILE: /opt/keycloak/conf/user-profile.json
     command: start
     volumes:
       - ./target/UserStorageFederation-0.0.1.jar:/opt/keycloak/providers/UserStorageFederation.jar
       - ./src/main/resources/application.properties:/opt/keycloak/conf/application.properties:ro
       - ./themes/keywind:/opt/keycloak/themes/keywind:ro
+      - ./conf/user-profile.json:/opt/keycloak/conf/user-profile.json:ro
     depends_on:
       - mariadb
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,1 +1,49 @@
-
+version: '3.8'
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.2.5
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres/keycloak
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: secret
+      QUARKUS_DATASOURCE_FEDERATION_JDBC_URL: jdbc:mariadb://mariadb:3306/adh6_prod
+      QUARKUS_DATASOURCE_FEDERATION_USERNAME: keycloak
+      QUARKUS_DATASOURCE_FEDERATION_PASSWORD: password
+      QUARKUS_DATASOURCE_FEDERATION_JDBC_DRIVER: org.mariadb.jdbc.MariaDbDataSource
+      QUARKUS_DATASOURCE_FEDERATION_JDBC_TRANSACTIONS: xa
+      KC_SPI_USER_PROFILE_DECLARATIVE_USER_PROFILE_CONFIG_FILE: /opt/keycloak/conf/user-profile.json
+    command: start-dev
+    volumes:
+      - ./target/UserStorageFederation-0.0.1.jar:/opt/keycloak/providers/UserStorageFederation.jar
+      - ./src/main/resources/application.properties:/opt/keycloak/conf/application.properties:ro
+      - ./themes/keywind:/opt/keycloak/themes/keywind:ro
+      - ./conf/user-profile.json:/opt/keycloak/conf/user-profile.json:ro
+    depends_on:
+      - mariadb
+      - postgres
+    ports:
+      - "8080:8080"
+  mariadb:
+    image: mariadb:11
+    environment:
+      MARIADB_DATABASE: adh6_prod
+      MARIADB_USER: keycloak
+      MARIADB_PASSWORD: password
+      MARIADB_ROOT_PASSWORD: root
+    volumes:
+      - mariadb_data:/var/lib/mysql
+      - ./sql:/docker-entrypoint-initdb.d:ro
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  mariadb_data:
+  postgres_data:


### PR DESCRIPTION
## Summary
- introduce a declarative user-profile.json under `conf/`
- mount the profile in both compose files
- point Keycloak to the profile file via environment variable

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686b9fdf8d548326bbdaf893df4a81d9