### PR TITLE
Fix user profile grouping for name fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The database schema and seed data are located under [`sql`](sql).
 
 All columns from the `adherents` table are exposed as user attributes when a user is retrieved. These values appear in the **Attributes** tab of the administration console without persisting anything back to the database. For example the `is_naina` column becomes the `isNaina` attribute (with a `is_naina` alias) and `created_at` is shown as both the built‑in created timestamp and a custom attribute. You can map any of these attributes to groups or roles as needed.
 
+The bundled `user-profile.json` groups these attributes under **ADH6**. Built‑in
+fields such as first and last name are duplicated as the `prenom` and `nom`
+attributes so they show up with the other values in the Attributes tab.
+
 ## 🧰 Prerequisites
 
 - Java 21

--- a/conf/user-profile.json
+++ b/conf/user-profile.json
@@ -7,10 +7,32 @@
             "name": "email"
         },
         {
-            "name": "firstName"
+            "name": "firstName",
+            "displayName": "First name",
+            "group": "ADH6"
         },
         {
-            "name": "lastName"
+            "name": "lastName",
+            "displayName": "Last name",
+            "group": "ADH6"
+        },
+        {
+            "name": "prenom",
+            "displayName": "First name",
+            "group": "ADH6",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
+        },
+        {
+            "name": "nom",
+            "displayName": "Last name",
+            "group": "ADH6",
+            "permissions": {
+                "view": ["admin"],
+                "edit": ["admin"]
+            }
         },
         {
             "name": "ldapLogin",

--- a/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
+++ b/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
@@ -181,6 +181,12 @@ public class ExternalUserAdapter extends AbstractUserAdapterFederatedStorage {
                 if (!alias.equals(name)) {
                     super.setSingleAttribute(alias, val.toString());
                 }
+                String columnAlias = ATTR_COLUMNS.get(name);
+                if (columnAlias != null &&
+                        !columnAlias.equals(name) &&
+                        !columnAlias.equals(alias)) {
+                    super.setSingleAttribute(columnAlias, val.toString());
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- show first and last name inside the ADH6 attributes group
- document that all external attributes, including names, appear under ADH6

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Could not download Quarkus BOM)*

------
https://chatgpt.com/codex/tasks/task_e_686bd43084a48326acd44f5de7c7ef2e