### PR TITLE
Fix createdTimestamp conversion and persistence

### DIFF
--- a/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
+++ b/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
@@ -286,12 +286,12 @@ public class ExternalUserAdapter extends AbstractUserAdapterFederatedStorage {
 
     @Override
     public void setCreatedTimestamp(Long timestamp) {
+        java.time.LocalDateTime ldt = null;
         if (timestamp != null) {
             java.time.Instant i = java.time.Instant.ofEpochMilli(timestamp);
-            user.setCreatedAt(java.time.LocalDateTime.ofInstant(i, java.time.ZoneId.systemDefault()));
-        } else {
-            user.setCreatedAt(null);
+            ldt = java.time.LocalDateTime.ofInstant(i, java.time.ZoneId.systemDefault());
         }
+        updateAttribute("createdAt", ldt);
         super.setCreatedTimestamp(timestamp);
     }
 
@@ -306,8 +306,18 @@ public class ExternalUserAdapter extends AbstractUserAdapterFederatedStorage {
 
     @Override
     public void setSingleAttribute(String name, String value) {
-        Object val = parseValue(name, value);
-        updateAttribute(name, val);
+        if ("createdAt".equals(name) || "created_at".equals(name)) {
+            Object val = parseValue("createdAt", value);
+            java.time.LocalDateTime ldt = (java.time.LocalDateTime) val;
+            Long ts = null;
+            if (ldt != null) {
+                ts = ldt.atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli();
+            }
+            setCreatedTimestamp(ts);
+        } else {
+            Object val = parseValue(name, value);
+            updateAttribute(name, val);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- synchronize `createdTimestamp` with the DB when set
- update `setSingleAttribute` to convert date strings to timestamps for `createdAt`

## Testing
- `mvn test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686fc254061c8326a7870821ae4cd3a1