### PR TITLE
Remove duplicate surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Summary
- drop the second `maven-surefire-plugin` block from `pom.xml`

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878b30e43108326ac814abe9510879e