### PR TITLE
Register BC provider at runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
             <version>1.78.1</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/net/minet/keycloak/hash/Md4Util.java
+++ b/src/main/java/net/minet/keycloak/hash/Md4Util.java
@@ -3,10 +3,17 @@ package net.minet.keycloak.hash;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import java.util.HexFormat;
 
 /** Utility for computing MD4 digests as hexadecimal strings. */
 public final class Md4Util {
+    static {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
     private Md4Util() {
     }
 


### PR DESCRIPTION
## Summary
- make Bouncy Castle provider available at runtime by loading it in `Md4Util`
- depend on `bcprov-jdk18on` at compile time

## Testing
- `mvn -q --no-transfer-progress verify` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6878b32260d883268ad035fc0ce4000d