### PR TITLE
Trim unused ExternalUser fields

### DIFF
--- a/src/main/java/net/minet/keycloak/spi/ExternalUserMapper.java
+++ b/src/main/java/net/minet/keycloak/spi/ExternalUserMapper.java
@@ -40,7 +40,6 @@ public final class ExternalUserMapper {
             new ColumnMapping("prenom", (u, rs) -> u.setFirstName(rs.getString("prenom"))),
             new ColumnMapping("mail", (u, rs) -> u.setEmail(rs.getString("mail"))),
             new ColumnMapping("login", (u, rs) -> u.setUsername(rs.getString("login"))),
-            new ColumnMapping("password", (u, rs) -> u.setPassword(rs.getString("password"))),
             new ColumnMapping("created_at", (u, rs) -> {
                 Timestamp ts = rs.getTimestamp("created_at");
                 if (ts != null) u.setCreatedAt(ts.toLocalDateTime());

--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
@@ -41,7 +41,7 @@ public class FdpSQLUserStorageProvider implements
 
     // Only retrieve columns we care about from the external DB
     private static final String SELECT_FIELDS = String.join(", ",
-            "id", "nom", "prenom", "mail", "login", "password",
+            "id", "nom", "prenom", "mail", "login",
             "created_at", "is_naina", "ldap_login");
 
     protected KeycloakSession session;

--- a/src/main/java/net/minet/keycloak/spi/entity/ExternalUser.java
+++ b/src/main/java/net/minet/keycloak/spi/entity/ExternalUser.java
@@ -1,6 +1,5 @@
 package net.minet.keycloak.spi.entity;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
@@ -8,28 +7,13 @@ import java.time.LocalDateTime;
  */
 public class ExternalUser {
     private Integer id;
-
     private String lastName;
     private String firstName;
     private String email;
     private String username;
-    private String password;
-    private LocalDate departureDate;
-    private String comments;
-    private Byte modeAssociation;
-    private String accessToken;
-    private String subnet;
-    private String ip;
-    private Integer chambreId;
     private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-    private Byte edminet;
     private Byte isNaina;
-    private Byte mailingList;
-    private Integer mailMembership;
     private String ldapLogin;
-    private LocalDateTime dateSignedHosting;
-    private LocalDateTime dateSignedAdhesion;
 
     public Integer getId() {
         return id;
@@ -71,92 +55,12 @@ public class ExternalUser {
         this.username = username;
     }
 
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public LocalDate getDepartureDate() {
-        return departureDate;
-    }
-
-    public void setDepartureDate(LocalDate departureDate) {
-        this.departureDate = departureDate;
-    }
-
-    public String getComments() {
-        return comments;
-    }
-
-    public void setComments(String comments) {
-        this.comments = comments;
-    }
-
-    public Byte getModeAssociation() {
-        return modeAssociation;
-    }
-
-    public void setModeAssociation(Byte modeAssociation) {
-        this.modeAssociation = modeAssociation;
-    }
-
-    public String getAccessToken() {
-        return accessToken;
-    }
-
-    public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-    }
-
-    public String getSubnet() {
-        return subnet;
-    }
-
-    public void setSubnet(String subnet) {
-        this.subnet = subnet;
-    }
-
-    public String getIp() {
-        return ip;
-    }
-
-    public void setIp(String ip) {
-        this.ip = ip;
-    }
-
-    public Integer getChambreId() {
-        return chambreId;
-    }
-
-    public void setChambreId(Integer chambreId) {
-        this.chambreId = chambreId;
-    }
-
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
     public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
-    }
-
-    public LocalDateTime getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public Byte getEdminet() {
-        return edminet;
-    }
-
-    public void setEdminet(Byte edminet) {
-        this.edminet = edminet;
     }
 
     public Byte getIsNaina() {
@@ -167,22 +71,6 @@ public class ExternalUser {
         this.isNaina = isNaina;
     }
 
-    public Byte getMailingList() {
-        return mailingList;
-    }
-
-    public void setMailingList(Byte mailingList) {
-        this.mailingList = mailingList;
-    }
-
-    public Integer getMailMembership() {
-        return mailMembership;
-    }
-
-    public void setMailMembership(Integer mailMembership) {
-        this.mailMembership = mailMembership;
-    }
-
     public String getLdapLogin() {
         return ldapLogin;
     }
@@ -190,22 +78,4 @@ public class ExternalUser {
     public void setLdapLogin(String ldapLogin) {
         this.ldapLogin = ldapLogin;
     }
-
-
-    public LocalDateTime getDateSignedHosting() {
-        return dateSignedHosting;
-    }
-
-    public void setDateSignedHosting(LocalDateTime dateSignedHosting) {
-        this.dateSignedHosting = dateSignedHosting;
-    }
-
-    public LocalDateTime getDateSignedAdhesion() {
-        return dateSignedAdhesion;
-    }
-
-    public void setDateSignedAdhesion(LocalDateTime dateSignedAdhesion) {
-        this.dateSignedAdhesion = dateSignedAdhesion;
-    }
 }
-


### PR DESCRIPTION
## Summary
- remove unused fields from `ExternalUser`
- stop selecting and mapping the deprecated `password` column

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6878b33de418832688364a7657b5b809