### PR TITLE
Add tests and dependency fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,17 +16,7 @@
         <quarkus.version>3.20.1</quarkus.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+
 
     <dependencies>
         <dependency>
@@ -55,11 +45,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/net/minet/keycloak/spi/ExternalUserAdapterTest.java
+++ b/src/test/java/net/minet/keycloak/spi/ExternalUserAdapterTest.java
@@ -1,0 +1,58 @@
+package net.minet.keycloak.spi;
+
+import net.minet.keycloak.spi.entity.ExternalUser;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.ResultSet;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExternalUserAdapterTest {
+    private DataSource ds;
+    private ExternalUser user;
+    private ExternalUserAdapter adapter;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        JdbcDataSource h2 = new JdbcDataSource();
+        h2.setURL("jdbc:h2:mem:adapter;MODE=MariaDB;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1");
+        ds = h2;
+        try (Connection c = ds.getConnection(); Statement s = c.createStatement()) {
+            s.executeUpdate("CREATE TABLE adherents (id INT PRIMARY KEY, created_at DATETIME)");
+            s.executeUpdate("INSERT INTO adherents (id, created_at) VALUES (1, NULL)");
+        }
+        user = new ExternalUser();
+        user.setId(1);
+        KeycloakSession session = Mockito.mock(KeycloakSession.class);
+        RealmModel realm = Mockito.mock(RealmModel.class);
+        ComponentModel model = Mockito.mock(ComponentModel.class);
+        Mockito.when(model.getId()).thenReturn("comp");
+        adapter = new ExternalUserAdapter(session, realm, model, user, ds);
+    }
+
+    @Test
+    public void testSetCreatedTimestampString() throws Exception {
+        adapter.setCreatedTimestamp("2025-01-01T10:00");
+        long expected = LocalDateTime.of(2025,1,1,10,0)
+                .atZone(ZoneOffset.UTC).toInstant().toEpochMilli();
+        assertEquals(expected, adapter.getCreatedTimestamp());
+        try (Connection c = ds.getConnection();
+             PreparedStatement ps = c.prepareStatement("SELECT created_at FROM adherents WHERE id=1")) {
+            ResultSet rs = ps.executeQuery();
+            assertTrue(rs.next());
+            assertNotNull(rs.getTimestamp(1));
+        }
+    }
+}

--- a/src/test/java/net/minet/keycloak/spi/ExternalUserMapperTest.java
+++ b/src/test/java/net/minet/keycloak/spi/ExternalUserMapperTest.java
@@ -1,0 +1,56 @@
+package net.minet.keycloak.spi;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExternalUserMapperTest {
+    private javax.sql.DataSource ds;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        JdbcDataSource h2 = new JdbcDataSource();
+        h2.setURL("jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1");
+        ds = h2;
+        try (Connection c = ds.getConnection(); Statement s = c.createStatement()) {
+            s.executeUpdate(
+                "CREATE TABLE adherents (" +
+                "id INT PRIMARY KEY, " +
+                "nom VARCHAR(255), " +
+                "prenom VARCHAR(255), " +
+                "mail VARCHAR(255), " +
+                "login VARCHAR(255), " +
+                "password VARCHAR(255), " +
+                "created_at DATETIME, " +
+                "is_naina TINYINT, " +
+                "ldap_login VARCHAR(255))");
+            s.executeUpdate(
+                "INSERT INTO adherents (id, nom, prenom, mail, login, password, created_at, is_naina, ldap_login) " +
+                "VALUES (1, 'Dupont', 'Jean', 'jean@example.com', 'jdupont', 'pass', '2025-01-01 10:00:00', 1, 'jdupont_ldap')");
+        }
+    }
+
+    @Test
+    public void testMapResultSet() throws Exception {
+        try (Connection c = ds.getConnection();
+             Statement s = c.createStatement();
+             ResultSet rs = s.executeQuery("SELECT * FROM adherents WHERE id=1")) {
+            assertTrue(rs.next());
+            ExternalUser user = ExternalUserMapper.map(rs);
+            assertEquals(1, user.getId());
+            assertEquals("Dupont", user.getLastName());
+            assertEquals("Jean", user.getFirstName());
+            assertEquals("jean@example.com", user.getEmail());
+            assertEquals("jdupont", user.getUsername());
+            assertEquals(Byte.valueOf((byte)1), user.getIsNaina());
+            assertEquals("jdupont_ldap", user.getLdapLogin());
+            assertNotNull(user.getCreatedAt());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- specify JUnit versions and drop unused BOM
- add ExternalUserMapperTest to verify entity mapping from JDBC
- add ExternalUserAdapterTest covering timestamp parsing

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687a919108d88326b886d978ac85dd0d