### PR TITLE
Fix log4j2 root logger properties

### DIFF
--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -8,5 +8,6 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss} %-5p [%c{2.}] (%t) %m%n
 
 loggers = root
-logger.root.level = ${sys:quarkus.log.level:-INFO}logger.root.appenderRefs = console
+logger.root.level = ${sys:quarkus.log.level:-INFO}
+logger.root.appenderRefs = console
 logger.root.appenderRef.console.ref = CONSOLE


### PR DESCRIPTION
## Summary
- fix root logger properties in log4j2 config

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_687ab40575908326ad81426b86cb9dd4