### PR TITLE
Add Javadoc for user storage classes

### DIFF
--- a/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
+++ b/src/main/java/net/minet/keycloak/spi/ExternalUserAdapter.java
@@ -22,6 +22,10 @@ import org.keycloak.storage.adapter.AbstractUserAdapterFederatedStorage;
 
 /**
  * Adapter that exposes an {@link ExternalUser} to Keycloak.
+ *
+ * <p>Mapped attributes are stored under multiple aliases: the Java bean name,
+ * a snake_case version and the actual column name. Updates to any alias keep
+ * the underlying entity and all other aliases in sync.</p>
  */
 public class ExternalUserAdapter extends AbstractUserAdapterFederatedStorage {
     private final ExternalUser user;

--- a/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
+++ b/src/main/java/net/minet/keycloak/spi/FdpSQLUserStorageProvider.java
@@ -26,8 +26,12 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 /**
- * User storage provider backed by an external SQL database. It exposes users
- * to Keycloak and supports credential validation and updates.
+ * User storage provider backed by an external SQL database.
+ *
+ * <p>Users are loaded via JDBC and wrapped in {@link ExternalUserAdapter} so
+ * that Keycloak can query and update them. Credential operations are handled
+ * through {@link #isValid(RealmModel, UserModel, CredentialInput)} and
+ * {@link #updateCredential(RealmModel, UserModel, CredentialInput)}.</p>
  */
 public class FdpSQLUserStorageProvider implements
         UserStorageProvider,


### PR DESCRIPTION
## Summary
- document `FdpSQLUserStorageProvider` with purpose and key methods
- describe attribute mapping for `ExternalUserAdapter`

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687ab40434b08326ac69f8cac837733d