### PR TITLE
Update Keycloak bootstrap env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ mvn package
    ```
 
    This brings up Keycloak along with MariaDB and PostgreSQL using the
-   configuration from `docker-compose.yml`. Keycloak will be available at
-   `http://localhost:8080`.
+    configuration from `docker-compose.yml`. Keycloak will be available at
+    `http://localhost:8080`.
+
+    The initial administrator account can be customised using the
+    environment variables `KC_BOOTSTRAP_ADMIN_USERNAME` and
+    `KC_BOOTSTRAP_ADMIN_PASSWORD` defined in the compose files.
 
 ## Database schema
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,8 +3,8 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.2.5
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       QUARKUS_DATASOURCE_FEDERATION_JDBC_URL: jdbc:mariadb://mariadb:3306/adh6_prod
       QUARKUS_DATASOURCE_FEDERATION_USERNAME: keycloak
       QUARKUS_DATASOURCE_FEDERATION_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:26.2.5
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres/keycloak
       KC_DB_USERNAME: keycloak


### PR DESCRIPTION
## Summary
- use `KC_BOOTSTRAP_ADMIN_USERNAME` and `KC_BOOTSTRAP_ADMIN_PASSWORD` in compose files
- document the new variables in the README

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687ac88e11f88326ad6e33d8abd102ec